### PR TITLE
Adds issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+As a [user or stakeholder type], I want [goal], so that [some reason/business value]
+
+## Notes
+[More detail on the user story]
+
+## Tasks
+_Any specific steps or tasks we want to make sure to do_
+- [ ] x
+
+## Resources
+-  y
+
+## Acceptance criteria
+_Acceptance criteria define when a work item is complete and working as expected._
+- [ ] z
+
+## Definition of done
+- [ ] Acceptance criteria met
+- [ ] Code, design, or content reviewed by team members
+- [ ] Tested with users

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
 
 _Include a summary of proposed changes._
 
+[:sunglasses: PREVIEW LINK](https://federalist-proxy.app.cloud.gov/preview/18f/cic-site/BRANCH-NAME/)
 
 ## Impacted areas of the application
 _List general components of the application that this PR will affect:_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+- Resolves #[_Issue number_]
+
+_Include a summary of proposed changes._
+
+
+## Impacted areas of the application
+_List general components of the application that this PR will affect:_
+
+-  x
+
+## Screenshots
+_Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface or front end change, include both a Before and After screenshot._


### PR DESCRIPTION
This adds standard writing templates for issues and PRs that will pre-populate the fields with categories writers can fill in, in order to prompt more clarity. 

@lauraGgit would you be up for reviewing?