### PR TITLE
prevent page from appearing on public search results

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,2 @@
----
----
-User-agent: *
-Disallow:
-Sitemap: {{ site.url }}/sitemap.xml
+User-agent: * 
+Disallow: /


### PR DESCRIPTION
## Summary

Given that this site is not yet in production, we should prevent the pages from appearing in public search results. This edit disables the search engine crawlers from indexing the page.